### PR TITLE
add dyndns CGI

### DIFF
--- a/dynaname
+++ b/dynaname
@@ -200,6 +200,7 @@ case "$DEFACTION" in
 		    test "$IPFAMILY" = "-6" || (test -n "$(validatev4 $i)" && echo "update add $DNSHOSTNAME $TTL A $i")
 		    test "$IPFAMILY" = "-4" || (test -n "$(validatev6 $i)" && echo "update add $DNSHOSTNAME $TTL AAAA $i")
 		done
+		[ -z "$TXTRECORD" ] || echo "update add $DNSHOSTNAME $TTL TXT \"$TXTRECORD\""
 		echo "update add $DNSHOSTNAME $TTL TXT \"Last update: $(TZ=UTC date "+%Y-%m-%d %H:%M:%S UTC")\""
 		echo "send"
 		echo "quit"

--- a/dyndnsupdate.cgi
+++ b/dyndnsupdate.cgi
@@ -11,6 +11,7 @@ use POSIX 'strftime';
 use File::Temp ':mktemp';
 
 my $debug=0;
+my $ttl=300;
 
 print header(),start_html(-title=>"dynamic DNS updater"),
     start_form(-method=>"get"),
@@ -46,9 +47,9 @@ if(param()) {
         "server $options{dnsserver}\n".
         "zone $zone\n".
         "update delete $options{hostname} $rr\n".
-        "update add $options{hostname} 300 $rr $options{myip}\n".
+        "update add $options{hostname} $ttl $rr $options{myip}\n".
         "update delete $options{hostname} TXT\n".
-        "update add $options{hostname} 300 TXT \"Last update: $time\"\n".
+        "update add $options{hostname} $ttl TXT \"Last update: $time\"\n".
         "send\nquit\n";
     if($debug) {
         open(DEBUG, ">", "/tmp/dyndns.log");

--- a/dyndnsupdate.cgi
+++ b/dyndnsupdate.cgi
@@ -3,7 +3,7 @@
 # Licensed under GPL v3 or later (see LICENSE file)
 #
 # use in FritzBox as custom Dynamic DNS provider with
-# https://yourserver.domain/dyndnsupdate.cgi?hostname=<domain>&myip=<ipaddr>&dnsserver=<username>&key=<pass>
+# https://yourserver.domain/dyndnsupdate.cgi?hostname=<domain>&myip=<ipaddr>&dnsserver=<username>&key=URLENCODEDKxxx.keyFILE
 
 use strict;
 use CGI ':standard';
@@ -65,9 +65,15 @@ if(param()) {
         "Key: $key[6]$key[7]\n".
         "Bits: AAA=\n";
     close $tmpfile;
+    print "Updating...\n",br;
     open(my $pipe, "| nsupdate -k $tmpfilename") or die $!;
     print $pipe $request;
     close $pipe;
+    if($?>>8) {
+        print "An error occurred. code ",$?>>8;
+    } else {
+        print "Updated successfully.";
+    }
     unlink $tmpfilename, $tmpfilename2;
 }
 

--- a/dyndnsupdate.cgi
+++ b/dyndnsupdate.cgi
@@ -1,0 +1,74 @@
+#!/usr/bin/perl -w
+# Copyright 2015 Bernhard M. Wiedemann
+# Licensed under GPL v3 or later (see LICENSE file)
+#
+# use in FritzBox as custom Dynamic DNS provider with
+# https://yourserver.domain/dyndnsupdate.cgi?hostname=<domain>&myip=<ipaddr>&dnsserver=<username>&key=<pass>
+
+use strict;
+use CGI ':standard';
+use POSIX 'strftime';
+use File::Temp ':mktemp';
+
+my $debug=0;
+
+print header(),start_html(-title=>"dynamic DNS updater"),
+    start_form(-method=>"get"),
+    textfield(-name=>'hostname'), " hostname to update", br,
+    textfield(-name=>'myip'), " IP (optional)", br,
+    textfield(-name=>'dnsserver'), " DNS server hosting the zone to update", br,
+    textarea(-name=>'key', -rows=>5, -cols=>30), " Kxxx.key file content", br,
+    submit(), br,
+    end_form();
+
+if(param()) {
+    my %options;
+    for my $p (qw(hostname myip dnsserver key)) {
+        $options{$p}=param($p);
+    }
+    if(!$options{myip}) {
+        # use sender's addr
+        $options{myip}=$ENV{HTTP_X_FORWARDED_FOR} || $ENV{REMOTE_ADDR};
+        $options{myip}=~s/::ffff://
+    }
+    $options{myip}=~s/[^0-9.:]//g; # sanitize
+    foreach my $p (qw(dnsserver hostname)) {
+        $options{$p}=~s/[^0-9a-z.-]//g; # sanitize
+    }
+    (my $zone=$options{hostname})=~s/^[0-9a-z-]+\.//;
+    my $time=POSIX::strftime('%F %H:%M:%S UTC', gmtime);
+    my $request =
+        "server $options{dnsserver}\n".
+        "zone $zone\n".
+        "update delete $options{hostname} A\n".
+        "update add $options{hostname} 300 A $options{myip}\n".
+        "update delete $options{hostname} TXT\n".
+        "update add $options{hostname} 300 TXT \"Last update: $time\"\n".
+        "send\nquit\n";
+    if($debug) {
+        open(DEBUG, ">", "/tmp/dyndns.log");
+        print DEBUG join("\n", map {"$_=$ENV{$_}"} sort keys %ENV);
+        if($ENV{REQUEST_METHOD} eq "POST") { print DEBUG <>}
+        print DEBUG $request;
+        close DEBUG;
+    }
+    umask(077);
+    my ($tmpfile, $tmpfilename)=mkstemps("/tmp/dyndns.XXXXXX", ".key");
+    print $tmpfile $options{key};
+    close $tmpfile;
+    (my $tmpfilename2=$tmpfilename)=~s/\.key/.private/;
+    open($tmpfile, ">", $tmpfilename2) or die $!;
+    my @key=split(" ",$options{key});
+    print $tmpfile
+        "Private-key-format: v1.3\n".
+        "Algorithm: $key[5]\n".
+        "Key: $key[6]$key[7]\n".
+        "Bits: AAA=\n";
+    close $tmpfile;
+    open(my $pipe, "| nsupdate -k $tmpfilename") or die $!;
+    print $pipe $request;
+    close $pipe;
+    unlink $tmpfilename, $tmpfilename2;
+}
+
+print end_html;

--- a/getip.sh
+++ b/getip.sh
@@ -20,6 +20,6 @@
 
 # This is going to be terse
 
-printf 'Content-type: text/plain\n\n'
+printf 'Content-type: text/plain\r\n\r\n'
 
 echo "$REMOTE_ADDR"


### PR DESCRIPTION
The CGI is designed to be stateless, getting all required information from the dumb client (e.g. home router) and passing it on to bind.
